### PR TITLE
fix(history.js): Change query check to rawQuery for sanitize

### DIFF
--- a/src/common/history.js
+++ b/src/common/history.js
@@ -36,12 +36,12 @@ const createLocation = (path, state, key, currentLocation) => {
 
     if (location.url === undefined) location.url = "";
 
-    if (location.query) {
-      if (location.query.charAt(0) !== "?")
-        location.query = "?" + location.query;
+    if (location.rawQuery) {
+      if (location.rawQuery.charAt(0) !== "?")
+        location.rawQuery = "?" + location.rawQuery;
     }
     else {
-      location.query = "";
+      location.rawQuery = "";
     }
 
     if (location.hash) {


### PR DESCRIPTION
Fixes: #45 

The snippet at history.js looks like string sanitization on `query`, but the received query is always an object. Therefore, sanitizing rawQuery should do the trick. It has been roughly tested that it does not affect anywhere else.

 